### PR TITLE
Replace all -msse3 occurances when cross-compiling for ARM

### DIFF
--- a/libviso2/CMakeLists.txt
+++ b/libviso2/CMakeLists.txt
@@ -8,7 +8,7 @@ option(ARM_CROSS_COMPILATION "ARM Cross Compilation" OFF)
 if(ARM_CROSS_COMPILATION)
   SET(CMAKE_SYSTEM_PROCESSOR arm)
   SET(CMAKE_CXX_FLAGS -mfpu=neon)
-else
+else(ARM_CROSS_COMPILATION)
   add_definitions(-msse3)
 endif(ARM_CROSS_COMPILATION)
 

--- a/libviso2/CMakeLists.txt
+++ b/libviso2/CMakeLists.txt
@@ -3,14 +3,13 @@ project(libviso2)
 
 find_package(catkin REQUIRED )
 
-#set(CMAKE_CXX_FLAGS "-msse3")
-add_definitions(-msse3)
-
 option(ARM_CROSS_COMPILATION "ARM Cross Compilation" OFF)
 
 if(ARM_CROSS_COMPILATION)
   SET(CMAKE_SYSTEM_PROCESSOR arm)
   SET(CMAKE_CXX_FLAGS -mfpu=neon)
+else
+  add_definitions(-msse3)
 endif(ARM_CROSS_COMPILATION)
 
 catkin_package(

--- a/libviso2/libviso2/CMakeLists.txt
+++ b/libviso2/libviso2/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories("${LIBVISO2_SRC_DIR}")
 if(ARM_CROSS_COMPILATION)
   SET(CMAKE_SYSTEM_PROCESSOR arm)
   SET(CMAKE_CXX_FLAGS -mfpu=neon)
-else
+else(ARM_CROSS_COMPILATION)
   add_definitions(-msse3)
 endif
 

--- a/libviso2/libviso2/CMakeLists.txt
+++ b/libviso2/libviso2/CMakeLists.txt
@@ -9,7 +9,12 @@ set (LIBVISO2_SRC_DIR src)
 include_directories("${LIBVISO2_SRC_DIR}")
 
 # use sse3 instruction set
-SET(CMAKE_CXX_FLAGS "-msse3")
+if(ARM_CROSS_COMPILATION)
+  SET(CMAKE_SYSTEM_PROCESSOR arm)
+  SET(CMAKE_CXX_FLAGS -mfpu=neon)
+else
+  add_definitions(-msse3)
+endif
 
 # sources
 FILE(GLOB LIBVISO2_SRC_FILES "src/*.cpp")

--- a/libviso2/libviso2/src/filter.h
+++ b/libviso2/libviso2/src/filter.h
@@ -26,9 +26,8 @@ Street, Fifth Floor, Boston, MA 02110-1301, USA
 #include "sse_to_neon.hpp"
 #else
 #include <emmintrin.h>
-#endif
-
 #include <pmmintrin.h>
+#endif
 
 // define fixed-width datatypes for Visual Studio projects
 #ifndef _MSC_VER

--- a/libviso2/libviso2/src/sse_to_neon.hpp
+++ b/libviso2/libviso2/src/sse_to_neon.hpp
@@ -11,7 +11,7 @@
 
 #include <arm_neon.h>
 
-#if defined(__MM_MALLOC_H)
+#if !defined(__MM_MALLOC_H)
 // copied from mm_malloc.h {
 #include <stdlib.h>
 

--- a/libviso2/package.xml
+++ b/libviso2/package.xml
@@ -25,6 +25,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <export>
-    <cpp lflags="-L${prefix}/lib -Wl,-rpath,${prefix}/lib -lviso2" cflags="-msse3 -I${prefix}/libviso2/src/"/>
+    <cpp lflags="-L${prefix}/lib -Wl,-rpath,${prefix}/lib -lviso2" cflags="-I${prefix}/libviso2/src/"/>
   </export>
 </package>

--- a/viso2_ros/CMakeLists.txt
+++ b/viso2_ros/CMakeLists.txt
@@ -33,7 +33,7 @@ catkin_package()
 if(ARM_CROSS_COMPILATION)
   SET(CMAKE_SYSTEM_PROCESSOR arm)
   SET(CMAKE_CXX_FLAGS -mfpu=neon)
-else
+else(ARM_CROSS_COMPILATION)
   add_definitions(-msse3)
 endif(ARM_CROSS_COMPILATION)
 

--- a/viso2_ros/CMakeLists.txt
+++ b/viso2_ros/CMakeLists.txt
@@ -30,10 +30,11 @@ generate_messages(
 
 catkin_package()
 
-add_definitions(-msse3)
 if(ARM_CROSS_COMPILATION)
   SET(CMAKE_SYSTEM_PROCESSOR arm)
   SET(CMAKE_CXX_FLAGS -mfpu=neon)
+else
+  add_definitions(-msse3)
 endif(ARM_CROSS_COMPILATION)
 
 include_directories(src ${libviso2_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})


### PR DESCRIPTION
- Tested on raspberry pi 3b+ with Kinetic
- Fixes https://github.com/srv/viso2/issues/35